### PR TITLE
Fixes empty directory issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function metalsmithUglify(options) {
         };
       });
 
-    if (options.concat) { jsFiles = [jsFiles]; }
+    if (options.concat && jsFiles.length) { jsFiles = [jsFiles]; }
 
     jsFiles.forEach(function (file) {
       var opts = assign({}, options);


### PR DESCRIPTION
This solves an issue where if the src directory is empty, or no matching files
end up getting passed through and the concat option was set, it would still pass in
an empty array into the minify method and try to minify a non-string. This checks
if the files array has a length before arrayifying it.