### PR TITLE
Make file ordering deterministic and fix tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/fixtures/**    text eol=lf

--- a/lib/normalize-options.js
+++ b/lib/normalize-options.js
@@ -70,7 +70,13 @@ function normalizeOrder(order) {
   order = arrify(order);
   order.push('**');
   return function (a, b) {
-    return matchPos(a, order) - matchPos(b, order);
+    var result = matchPos(a, order) - matchPos(b, order);
+
+    if (result === 0) {
+      result = a.toLowerCase().localeCompare(b.toLowerCase());
+    }
+
+    return result;
   };
 }
 

--- a/lib/normalize-options.js
+++ b/lib/normalize-options.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var path      = require('path');
+var path      = require('upath');
 var arrify    = require('arrify');
 var assign    = require('object-assign');
 var minimatch = require('minimatch');

--- a/lib/relative.js
+++ b/lib/relative.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var path = require('path');
+var path = require('upath');
 
 module.exports = function relative(from, to) {
   return path.relative(path.dirname(from), to);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "is-string": "^1.0.4",
     "minimatch": "^3.0.0",
     "object-assign": "^4.0.1",
-    "uglify-js": "^2.6.2"
+    "uglify-js": "^2.6.2",
+    "upath": "^0.1.7"
   }
 }

--- a/test/fixtures/build-test/concat-order.js
+++ b/test/fixtures/build-test/concat-order.js
@@ -1,2 +1,2 @@
-!function(n){var i={init:function(n){console.log("loaded dir/test.js")}};n(function(){i.init()})}(jQuery),function(n){var i={init:function(n){console.log("loaded test.js")}};n(function(){i.init()})}(jQuery);
+!function(n){var i={init:function(n){console.log("loaded dir/test.js")}};n(function(){i.init()})}(jQuery),function(n){var i={init:function(n){console.log("loaded dir/testb.js")}};n(function(){i.init()})}(jQuery),function(n){var i={init:function(n){console.log("loaded dir/testz.js")}};n(function(){i.init()})}(jQuery),function(n){var i={init:function(n){console.log("loaded test.js")}};n(function(){i.init()})}(jQuery);
 //# sourceMappingURL=app.min.js.map

--- a/test/fixtures/src/dir/testb.js
+++ b/test/fixtures/src/dir/testb.js
@@ -1,0 +1,17 @@
+(function ($) {
+  // %'all'%
+  var plugin = {
+    init: function (selector) {
+      console.log('loaded dir/testb.js');
+    }
+  };
+  //! %'some'% %'all'%
+  // @preserve %'some'% %'all'%
+  // @license %'some'% %'all'%
+  // @cc_on %'some'% %'all'%
+  // %'custom'%
+  $(function () {
+    plugin.init();
+  });
+
+})(jQuery);

--- a/test/fixtures/src/dir/testz.js
+++ b/test/fixtures/src/dir/testz.js
@@ -1,0 +1,17 @@
+(function ($) {
+  // %'all'%
+  var plugin = {
+    init: function (selector) {
+      console.log('loaded dir/testz.js');
+    }
+  };
+  //! %'some'% %'all'%
+  // @preserve %'some'% %'all'%
+  // @license %'some'% %'all'%
+  // @cc_on %'some'% %'all'%
+  // %'custom'%
+  $(function () {
+    plugin.init();
+  });
+
+})(jQuery);

--- a/test/metalsmith-uglify-test.js
+++ b/test/metalsmith-uglify-test.js
@@ -5,16 +5,23 @@
 
 var fs         = require('fs');
 var uglify     = require('../');
-var path       = require('path');
+var path       = require('upath');
 var expect     = require('chai').expect;
 var Metalsmith = require('metalsmith');
 
+var normalizePaths = require('./normalize-paths');
+
 var FIXTURES   = path.join(__dirname, 'fixtures');
+
+function getMetalsmith() {
+  return new Metalsmith(FIXTURES)
+      .use(normalizePaths());
+}
 
 describe('metalsmith-uglify', function () {
 
   it('should uglify all .js files', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify())
       .build(function (err, files) {
         if (err) { return done(err); }
@@ -28,7 +35,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should filter by glob', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         filter: 'dir/**/*.js'
       }))
@@ -41,7 +48,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should filter by array of filepaths', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         filter: ['test.js']
       }))
@@ -54,7 +61,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should filter by array of filepaths', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         filter: ['test.js', 'dir/*.js']
       }))
@@ -68,7 +75,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should not filter if odd filter is passed', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         filter: {}
       }))
@@ -79,10 +86,10 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should filter by function', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         filter: function (filepath) {
-          return require('path').extname(filepath) === '.js';
+          return require('upath').extname(filepath) === '.js';
         }
       }))
       .build(function (err, files) {
@@ -95,7 +102,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should remove originals', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         removeOriginal: true
       }))
@@ -109,7 +116,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should preserve all comments', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         preserveComments: 'all'
       }))
@@ -125,7 +132,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should preserve some comments', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         preserveComments: 'some'
       }))
@@ -141,7 +148,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should preserve contents by function', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         preserveComments: function (node, comment) {
           return comment.value.indexOf('custom') !== -1;
@@ -159,7 +166,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should catch the error gracefully', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         filter: '**/*.jsx'
       }))
@@ -170,7 +177,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should build out sourcemaps', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         sourceMap: true
       }))
@@ -194,7 +201,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should use a function to make the sourcemap function', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         sourceMap: function (filepath) {
           return filepath + '.js2.map';
@@ -218,7 +225,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should use tokenized string', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         sourceMap: 'maps/{{dir}}/{{name}}.map'
       }))
@@ -240,7 +247,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should not do anything else is passed as sourcemap', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         sourceMap: {}
       }))
@@ -258,7 +265,7 @@ describe('metalsmith-uglify', function () {
   });
 
   it('should concatenate all files', function (done) {
-    var build = new Metalsmith(FIXTURES)
+    var build = getMetalsmith()
       .use(uglify({
         sourceMap: true,
         concat: 'app.min.js'
@@ -289,8 +296,8 @@ describe('metalsmith-uglify', function () {
     }
   });
 
-  it('should order the files to be concatenate', function (done) {
-    var build = new Metalsmith(FIXTURES)
+  it('should order the files to be concatenated', function (done) {
+    var build = getMetalsmith()
       .use(uglify({
         sourceMap: true,
         concat: 'app.min.js',

--- a/test/metalsmith-uglify-test.js
+++ b/test/metalsmith-uglify-test.js
@@ -41,20 +41,31 @@ describe('metalsmith-uglify', function () {
       }))
       .build(function (err, files) {
         if (err) { return done(err); }
-        expect(Object.keys(files)).to.have.length(4);
+        expect(Object.keys(files)).to.have.length(8);
         expect(files['dir/test.min.js']).to.be.instanceof(Object);
         done();
       });
   });
 
-  it('should filter by array of filepaths', function (done) {
+  it('should filter by single-item array of filepaths', function (done) {
     var build = getMetalsmith()
       .use(uglify({
         filter: ['test.js']
       }))
       .build(function (err, files) {
         if (err) { return done(err); }
-        expect(Object.keys(files)).to.have.length(4);
+        expect(files).to.have.keys([
+          // Uglified files
+          'test.js',
+          'test.min.js',
+
+          // Un-uglified files
+          'dir/test.js',
+          'err.jsx',
+          'dir/testb.js',
+          'dir/testz.js',
+        ]);
+        expect(Object.keys(files)).to.have.length(6);
         expect(files['test.min.js']).to.be.instanceof(Object);
         done();
       });
@@ -67,7 +78,20 @@ describe('metalsmith-uglify', function () {
       }))
       .build(function (err, files) {
         if (err) { return done(err); }
-        expect(Object.keys(files)).to.have.length(5);
+        expect(files).to.have.keys([
+          // Uglified files
+          'dir/test.js',
+          'dir/test.min.js',
+          'dir/testb.js',
+          'dir/testb.min.js',
+          'dir/testz.js',
+          'dir/testz.min.js',
+          'test.js',
+          'test.min.js',
+          // Un-uglified files
+          'err.jsx',
+        ]);
+        expect(Object.keys(files)).to.have.length(9);
         expect(files['test.min.js']).to.be.instanceof(Object);
         expect(files['dir/test.min.js']).to.be.instanceof(Object);
         done();
@@ -94,7 +118,7 @@ describe('metalsmith-uglify', function () {
       }))
       .build(function (err, files) {
         if (err) { return done(err); }
-        expect(Object.keys(files)).to.have.length(5);
+        expect(Object.keys(files)).to.have.length(9);
         expect(files['test.min.js']).to.be.instanceof(Object);
         expect(files['dir/test.min.js']).to.be.instanceof(Object);
         done();
@@ -186,11 +210,17 @@ describe('metalsmith-uglify', function () {
         expect(files).to.have.keys([
           'err.jsx',
           'test.js',
-          'dir/test.js',
           'test.min.js.map',
           'test.min.js',
+          'dir/test.js',
           'dir/test.min.js.map',
-          'dir/test.min.js'
+          'dir/test.min.js',
+          'dir/testb.js',
+          'dir/testb.min.js.map',
+          'dir/testb.min.js',
+          'dir/testz.js',
+          'dir/testz.min.js.map',
+          'dir/testz.min.js'
         ]);
         expect(files['test.min.js'].contents.toString())
           .to.contain('//# sourceMappingURL=test.min.js.map');
@@ -212,11 +242,17 @@ describe('metalsmith-uglify', function () {
         expect(files).to.have.keys([
           'err.jsx',
           'test.js',
-          'dir/test.js',
           'test.min.js.js2.map',
           'test.min.js',
+          'dir/test.js',
           'dir/test.min.js.js2.map',
-          'dir/test.min.js'
+          'dir/test.min.js',
+          'dir/testb.js',
+          'dir/testb.min.js.js2.map',
+          'dir/testb.min.js',
+          'dir/testz.js',
+          'dir/testz.min.js.js2.map',
+          'dir/testz.min.js'
         ]);
         fileEquality(files['test.min.js.js2.map'], '2/test.min.js.js2.map', true);
         fileEquality(files['dir/test.min.js.js2.map'], '2/dir/test.min.js.js2.map', true);
@@ -234,11 +270,17 @@ describe('metalsmith-uglify', function () {
         expect(files).to.have.keys([
           'err.jsx',
           'test.js',
-          'dir/test.js',
           'maps/test.min.js.map',
           'test.min.js',
+          'dir/test.js',
+          'dir/test.min.js',
           'maps/dir/test.min.js.map',
-          'dir/test.min.js'
+          'dir/testb.js',
+          'dir/testb.min.js',
+          'maps/dir/testb.min.js.map',
+          'dir/testz.js',
+          'dir/testz.min.js',
+          'maps/dir/testz.min.js.map',
         ]);
         fileEquality(files['maps/test.min.js.map'], '3/maps/test.min.js.map', true);
         fileEquality(files['maps/dir/test.min.js.map'], '3/maps/dir/test.min.js.map', true);
@@ -256,9 +298,13 @@ describe('metalsmith-uglify', function () {
         expect(files).to.have.keys([
           'err.jsx',
           'test.js',
-          'dir/test.js',
           'test.min.js',
-          'dir/test.min.js'
+          'dir/test.js',
+          'dir/test.min.js',
+          'dir/testb.js',
+          'dir/testb.min.js',
+          'dir/testz.js',
+          'dir/testz.min.js',
         ]);
         done();
       });
@@ -276,6 +322,8 @@ describe('metalsmith-uglify', function () {
           'err.jsx',
           'test.js',
           'dir/test.js',
+          'dir/testb.js',
+          'dir/testz.js',
           'app.min.js',
           'app.min.js.map'
         ]);
@@ -309,6 +357,8 @@ describe('metalsmith-uglify', function () {
           'err.jsx',
           'test.js',
           'dir/test.js',
+          'dir/testb.js',
+          'dir/testz.js',
           'app.min.js',
           'app.min.js.map'
         ]);

--- a/test/normalize-paths.js
+++ b/test/normalize-paths.js
@@ -4,11 +4,13 @@
  * Normalize metalsmith filenames in files object so that paths use '/' even on Windows
  */
 module.exports = function normalizePathsIfNecessaryPlugin(options) {
-  let replaceBackslashes = str => str.replace(/\\/g, "/");
+  var replaceBackslashes = function(str) {
+    return str.replace(/\\/g, "/");
+  }
 
   return function normalizePathsIfNecessary(files, metalsmith, done) {
     Object.keys(files).forEach(fileName => {
-      let normalizedFileName = replaceBackslashes(fileName);
+      var normalizedFileName = replaceBackslashes(fileName);
       if (fileName !== normalizedFileName) {
         files[normalizedFileName] = files[fileName];
         delete files[fileName];

--- a/test/normalize-paths.js
+++ b/test/normalize-paths.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/**
+ * Normalize metalsmith filenames in files object so that paths use '/' even on Windows
+ */
+module.exports = function normalizePathsIfNecessaryPlugin(options) {
+  let replaceBackslashes = str => str.replace(/\\/g, "/");
+
+  return function normalizePathsIfNecessary(files, metalsmith, done) {
+    Object.keys(files).forEach(fileName => {
+      let normalizedFileName = replaceBackslashes(fileName);
+      if (fileName !== normalizedFileName) {
+        files[normalizedFileName] = files[fileName];
+        delete files[fileName];
+      }
+    });
+    done();
+  }
+};


### PR DESCRIPTION
File ordering was not deterministic.  This was bothering me because I am using metalsmith-fingerprint and uploading my content to a CDN, and I don't want to generate a new JS bundle with a new filename every time I build if the content hasn't actually changed, so i want the order of the uglified files, and therefore the bundle, to be deterministic.

Also, tests didn't pass on Windows.

This PR fixes both issues.