### PR TITLE
Use new UglifyJS fromString map options

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -7,31 +7,18 @@ var arrify = require('arrify');
 module.exports = function minify(files, options) {
   var mangled;
   files = arrify(files);
-  var contents = files.map(function (file) {
-    return file.contents.toString();
+  var contents = {};
+  files.forEach(function (file) {
+    contents[file.path] = file.contents.toString();
   });
   var paths = files.map(function (file) { return file.path; });
 
   try {
-
     mangled = uglify.minify(contents, options);
-    mangled.map = processSourceMap(files, mangled.map);
     return mangled;
-
   } catch (err) {
     return new Error(
       format('uglify: Failed to minify %s: %s', paths.join(', '), err.stack)
     );
   }
 };
-
-function processSourceMap(files, map) {
-  if (!map) { return null; }
-  map = JSON.parse(map);
-  map.sourcesContent = [];
-  files.forEach(function (file, i) {
-    map.sources[i] = file.path;
-    map.sourcesContent[i] = file.contents.toString();
-  });
-  return JSON.stringify(map);
-}

--- a/lib/normalize-options.js
+++ b/lib/normalize-options.js
@@ -22,6 +22,7 @@ module.exports = function normalizeOptions(options) {
   options.order = normalizeOrder(options.order);
   options.filter = normalizeFilter(options.filter);
   options.sourceMap = normalizeSourceMapPath(options.sourceMap);
+  options.sourceMapIncludeSources = true;
   // TODO make getMinPath configurable
   options.getMinPath = getMinPath;
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "is-string": "^1.0.4",
     "minimatch": "^3.0.0",
     "object-assign": "^4.0.1",
-    "uglify-js": "^2.6.2",
+    "uglify-js": "^2.7.3",
     "upath": "^0.1.7"
   }
 }


### PR DESCRIPTION
This implements [a recent UglifyJS update](https://github.com/mishoo/UglifyJS2/commit/85924bb32e1c27f555aad1651f4575b45bcbadb1) that allows specifying files to minify as a map of file paths / file contents when using the `fromString` option.

This fixes bugs where only the first file name was included in the source maps when using concatenation, which made errors difficult to track (see issue #15).

I removed the `processSourceMap` stuff as I realized that the new way to pass file names combined with UglifyJS' `sourceMapIncludeSources` option did the same thing.

Unfortunately, I didn't do thorough tests to ensure that every little thing still works after bumping UglifyJs' version but I can confirm this does fix the source maps when using concatenation.